### PR TITLE
Refactor downloadable buffer wrapper

### DIFF
--- a/src/buffer/gaussian.rs
+++ b/src/buffer/gaussian.rs
@@ -3,11 +3,10 @@ use glam::*;
 use wgpu::util::DeviceExt;
 
 use crate::{
-    BufferWrapper, DownloadBufferError, DownloadableBufferWrapper, Gaussian, GaussianCov3dConfig,
-    GaussianCov3dHalfConfig, GaussianCov3dRotScaleConfig, GaussianCov3dSingleConfig,
-    GaussianShConfig, GaussianShHalfConfig, GaussianShNoneConfig, GaussianShNorm8Config,
-    GaussianShSingleConfig, Gaussians, GaussiansBufferTryFromBufferError,
-    GaussiansBufferUpdateError, GaussiansBufferUpdateRangeError,
+    BufferWrapper, DownloadBufferError, Gaussian, GaussianCov3dConfig, GaussianCov3dHalfConfig,
+    GaussianCov3dRotScaleConfig, GaussianCov3dSingleConfig, GaussianShConfig, GaussianShHalfConfig,
+    GaussianShNoneConfig, GaussianShNorm8Config, GaussianShSingleConfig, Gaussians,
+    GaussiansBufferTryFromBufferError, GaussiansBufferUpdateError, GaussiansBufferUpdateRangeError,
 };
 
 /// The Gaussians storage buffer.

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -17,27 +17,19 @@ pub trait BufferWrapper: Into<wgpu::Buffer> {
 
     /// Returns a reference to the buffer data.
     fn buffer(&self) -> &wgpu::Buffer;
-}
 
-impl BufferWrapper for wgpu::Buffer {
-    fn buffer(&self) -> &wgpu::Buffer {
-        self
-    }
-}
-
-/// A trait to enable any [`BufferWrapper`] to download the buffer data.
-///
-/// The buffer should be created with [`wgpu::BufferUsages::COPY_SRC`] usage.
-pub trait DownloadableBufferWrapper: BufferWrapper + Send + Sync {
-    /// Download the buffer data.
+    /// Download the buffer data into a [`Vec`].
     fn download<T: bytemuck::NoUninit + bytemuck::AnyBitPattern>(
         &self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
-    ) -> impl Future<Output = Result<Vec<T>, DownloadBufferError>> + Send {
+    ) -> impl Future<Output = Result<Vec<T>, DownloadBufferError>> + Send
+    where
+        Self: Send + Sync,
+    {
         async {
             let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("Selection Download Encoder"),
+                label: Some("Buffer Wrapper Download Encoder"),
             });
             let download = self.prepare_download(device, &mut encoder);
             queue.submit(Some(encoder.finish()));
@@ -56,7 +48,7 @@ pub trait DownloadableBufferWrapper: BufferWrapper + Send + Sync {
         encoder: &mut wgpu::CommandEncoder,
     ) -> wgpu::Buffer {
         let download = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("Selection Download Buffer"),
+            label: Some("Buffer Wrapper Prepare Download Buffer"),
             size: self.buffer().size(),
             usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
             mapped_at_creation: false,
@@ -93,7 +85,11 @@ pub trait DownloadableBufferWrapper: BufferWrapper + Send + Sync {
     }
 }
 
-impl<T: BufferWrapper + Send + Sync> DownloadableBufferWrapper for T {}
+impl BufferWrapper for wgpu::Buffer {
+    fn buffer(&self) -> &wgpu::Buffer {
+        self
+    }
+}
 
 /// A [`BufferWrapper`] with a fixed size that can be validated from a [`wgpu::Buffer`].
 pub trait FixedSizeBufferWrapper: BufferWrapper + TryFrom<wgpu::Buffer> {
@@ -118,5 +114,21 @@ pub trait FixedSizeBufferWrapper: BufferWrapper + TryFrom<wgpu::Buffer> {
             });
         }
         Ok(())
+    }
+
+    /// Download a single [`FixedSizeBufferWrapper::Pod`].
+    fn download_single(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+    ) -> impl Future<Output = Result<Self::Pod, DownloadBufferError>> + Send
+    where
+        Self: Send + Sync,
+        Self::Pod: bytemuck::NoUninit + bytemuck::AnyBitPattern,
+    {
+        async move {
+            let vec = self.download::<Self::Pod>(device, queue).await?;
+            Ok(vec.into_iter().next().expect("downloaded single element"))
+        }
     }
 }

--- a/tests/buffer/gaussian.rs
+++ b/tests/buffer/gaussian.rs
@@ -1,7 +1,5 @@
 use assert_matches::assert_matches;
-use wgpu_3dgs_core::{
-    BufferWrapper, DownloadableBufferWrapper, Gaussian, GaussianPod, Gaussians, GaussiansBuffer,
-};
+use wgpu_3dgs_core::{BufferWrapper, Gaussian, GaussianPod, Gaussians, GaussiansBuffer};
 
 use crate::{
     common::{TestContext, given},

--- a/tests/buffer/gaussian_transform.rs
+++ b/tests/buffer/gaussian_transform.rs
@@ -1,8 +1,8 @@
 use assert_matches::assert_matches;
 use wgpu::util::DeviceExt;
 use wgpu_3dgs_core::{
-    BufferWrapper, DownloadableBufferWrapper, GaussianDisplayMode, GaussianShDegree,
-    GaussianTransformBuffer, GaussianTransformPod,
+    BufferWrapper, GaussianDisplayMode, GaussianShDegree, GaussianTransformBuffer,
+    GaussianTransformPod,
 };
 
 use crate::common::TestContext;

--- a/tests/buffer/mod.rs
+++ b/tests/buffer/mod.rs
@@ -34,12 +34,9 @@ fn test_downloadable_buffer_wrapper_download_should_download_buffer_data() {
                 | wgpu::BufferUsages::COPY_SRC,
         });
 
-    {
-        use wgpu_3dgs_core::DownloadableBufferWrapper;
-        let downloaded = pollster::block_on(buffer.download::<u32>(&ctx.device, &ctx.queue));
+    let downloaded = pollster::block_on(buffer.download::<u32>(&ctx.device, &ctx.queue));
 
-        assert_matches!(downloaded, Ok(data) if data == vec![1u32, 2, 3, 4]);
-    }
+    assert_matches!(downloaded, Ok(data) if data == vec![1u32, 2, 3, 4]);
 }
 
 #[derive(Debug)]
@@ -113,4 +110,24 @@ fn test_fixed_size_buffer_wrapper_verify_buffer_size_when_size_mismatched_should
             expected_size: 4
         })
     );
+}
+
+#[test]
+fn test_fixed_size_buffer_download_single_should_download_single_pod() {
+    let ctx = common::TestContext::new();
+    let buffer = ctx
+        .device
+        .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Test Buffer"),
+            contents: bytemuck::bytes_of(&42u32),
+            usage: wgpu::BufferUsages::UNIFORM
+                | wgpu::BufferUsages::COPY_DST
+                | wgpu::BufferUsages::COPY_SRC,
+        });
+
+    let wrapper = TestBufferWrapper::try_from(buffer).expect("try_from");
+
+    let downloaded = pollster::block_on(wrapper.download_single(&ctx.device, &ctx.queue));
+
+    assert_matches!(downloaded, Ok(42u32));
 }

--- a/tests/buffer/model_transform.rs
+++ b/tests/buffer/model_transform.rs
@@ -1,8 +1,6 @@
 use glam::*;
 use wgpu::util::DeviceExt;
-use wgpu_3dgs_core::{
-    BufferWrapper, DownloadableBufferWrapper, ModelTransformBuffer, ModelTransformPod,
-};
+use wgpu_3dgs_core::{BufferWrapper, ModelTransformBuffer, ModelTransformPod};
 
 use crate::common::TestContext;
 

--- a/tests/e2e/compute_bundle.rs
+++ b/tests/e2e/compute_bundle.rs
@@ -1,8 +1,7 @@
 use assert_matches::assert_matches;
 use wgpu::util::DeviceExt;
 use wgpu_3dgs_core::{
-    ComputeBundleBuildError, ComputeBundleBuilder, ComputeBundleCreateError,
-    DownloadableBufferWrapper,
+    BufferWrapper, ComputeBundleBuildError, ComputeBundleBuilder, ComputeBundleCreateError,
 };
 
 use crate::common::{TestContext, shader};

--- a/tests/shader/gaussian.rs
+++ b/tests/shader/gaussian.rs
@@ -1,6 +1,6 @@
 use wgpu_3dgs_core::{
-    BufferWrapper, ComputeBundleBuilder, DownloadableBufferWrapper, GaussianCov3dConfig,
-    GaussianPod, GaussianPodWithShHalfCov3dSingleConfigs, GaussianPodWithShNorm8Cov3dSingleConfigs,
+    BufferWrapper, ComputeBundleBuilder, GaussianCov3dConfig, GaussianPod,
+    GaussianPodWithShHalfCov3dSingleConfigs, GaussianPodWithShNorm8Cov3dSingleConfigs,
     GaussianPodWithShSingleCov3dHalfConfigs, GaussianPodWithShSingleCov3dRotScaleConfigs,
     GaussianPodWithShSingleCov3dSingleConfigs, Gaussians, GaussiansBuffer, glam::*,
 };

--- a/tests/shader/gaussian_transform.rs
+++ b/tests/shader/gaussian_transform.rs
@@ -1,6 +1,6 @@
 use wgpu_3dgs_core::{
-    BufferWrapper, ComputeBundleBuilder, DownloadableBufferWrapper, GaussianDisplayMode,
-    GaussianShDegree, GaussianTransformBuffer, GaussianTransformPod,
+    BufferWrapper, ComputeBundleBuilder, GaussianDisplayMode, GaussianShDegree,
+    GaussianTransformBuffer, GaussianTransformPod,
 };
 
 use crate::{common::TestContext, inline_wesl_pkg};

--- a/tests/shader/model_transform.rs
+++ b/tests/shader/model_transform.rs
@@ -1,7 +1,6 @@
 use wgpu::util::DeviceExt;
 use wgpu_3dgs_core::{
-    BufferWrapper, ComputeBundleBuilder, DownloadableBufferWrapper, ModelTransformBuffer,
-    ModelTransformPod, glam::*,
+    BufferWrapper, ComputeBundleBuilder, ModelTransformBuffer, ModelTransformPod, glam::*,
 };
 
 use crate::{common::TestContext, inline_wesl_pkg};


### PR DESCRIPTION
- Remove `DownloadableBufferWrapper` and move the functions into `BufferWrapper` with function level trait bound
- Add `download_single` for `FixedSizeBufferWrapper`
- Fixed buffer wrapper debug labels
- Update tests

Closes #4 